### PR TITLE
Convert InputText cursor to text

### DIFF
--- a/buffet/src/styled/InputText/InputText.js
+++ b/buffet/src/styled/InputText/InputText.js
@@ -16,7 +16,7 @@ const InputText = styled.input`
   padding: 0 ${sizes.input.padding};
   font-weight: ${sizes.input.fontWeight};
   font-size: ${sizes.input.fontSize};
-  cursor: pointer;
+  cursor: text;
   outline: 0;
   border: 1px solid ${colors.lightGrey};
   border-radius: ${sizes.radius};


### PR DESCRIPTION
Instead of a pointer, a text cursor is appropriate in a text field.