### PR TITLE
Restore slack badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
     <a href="https://travis-ci.org/strapi/buffet">
       <img src="https://travis-ci.org/strapi/buffet.svg?branch=master" alt="Travis Build Status" />
     </a>
-    <!-- <a href="http://slack.strapi.io">
-      <img src="https://strapi-slack.herokuapp.com/badge.svg" alt="Strapi on Slack" />
-    </a> -->
+    <a href="http://slack.strapi.io">
+      <img src="http://slack.strapi.io/badge.svg" alt="Strapi on Slack" />
+    </a>
   </p>
 </div>
 


### PR DESCRIPTION
I restored the Slack badge in the README.md file since I fixed it.
The badge is also updated with the correct number of users we have on Slack.

Here is the result:

![http://slack.strapi.io/badge.svg](http://slack.strapi.io/badge.svg)