### PR TITLE
Fixes import typo in InputText.stories.js

### DIFF
--- a/buffet/stories/components/InputText.stories.js
+++ b/buffet/stories/components/InputText.stories.js
@@ -76,7 +76,7 @@ function InputTextStory() {
           <Pre>
             {`
 import React, { useState } from 'react';
-import { InputText } from 'buffet';
+import { InputText } from 'buffetjs';
 
 function Example(props) {
   const [val, setValue] = useState('');


### PR DESCRIPTION
Updates "buffet" to "buffetjs" in the import statement

Before
<img width="260" alt="Screenshot 2019-06-26 at 17 07 58" src="https://user-images.githubusercontent.com/15960526/60196448-197fb800-9835-11e9-8d92-91d0aa58be7e.png">

After
<img width="273" alt="Screenshot 2019-06-26 at 17 08 15" src="https://user-images.githubusercontent.com/15960526/60196458-1f759900-9835-11e9-89e5-3ee8cac23fab.png">
