### PR TITLE
Fixes #32 - Pass in className prop

### DIFF
--- a/buffet/src/commonPropTypes/input/commonPropTypes.js
+++ b/buffet/src/commonPropTypes/input/commonPropTypes.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 export default {
   autoComplete: PropTypes.string,
   autoFocus: PropTypes.bool,
+  className: PropTypes.string,
   id: PropTypes.string,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,

--- a/buffet/src/commonPropTypes/input/uncontrolledPropTypes.js
+++ b/buffet/src/commonPropTypes/input/uncontrolledPropTypes.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 
 export default {
+  className: PropTypes.string,
   onChange: PropTypes.func,
 };

--- a/buffet/src/commonPropTypes/list/propTypes.js
+++ b/buffet/src/commonPropTypes/list/propTypes.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 
 export default {
+  className: PropTypes.string,
   customRowComponent: PropTypes.func,
   items: PropTypes.instanceOf(Array),
 };

--- a/buffet/src/components/Checkbox/index.js
+++ b/buffet/src/components/Checkbox/index.js
@@ -18,6 +18,7 @@ import Label from '../Label';
 
 function Checkbox({
   autoFocus,
+  className,
   id,
   message,
   name,
@@ -37,7 +38,7 @@ function Checkbox({
   };
 
   return (
-    <CheckboxWrapper>
+    <CheckboxWrapper className={className}>
       <StyledCheckbox
         {...rest}
         autoFocus={autoFocus}

--- a/buffet/src/components/DatePicker/index.js
+++ b/buffet/src/components/DatePicker/index.js
@@ -50,11 +50,11 @@ class DatePicker extends React.PureComponent {
   };
 
   render() {
-    const { displayFormat, id, name } = this.props;
+    const { className, displayFormat, id, name } = this.props;
     const { date, isFocused } = this.state;
 
     return (
-      <Datepicker>
+      <Datepicker className={className}>
         <SingleDatePicker
           date={date}
           focused={isFocused}

--- a/buffet/src/components/Enumeration/index.js
+++ b/buffet/src/components/Enumeration/index.js
@@ -17,9 +17,9 @@ import StyledEnumeration, {
   EnumerationWrapper,
 } from '../../styled/Enumeration';
 
-function Enumeration({ id, name, onChange, options, value }) {
+function Enumeration({ id, className, name, onChange, options, value }) {
   return (
-    <EnumerationWrapper>
+    <EnumerationWrapper className={className}>
       {options.map(option => (
         <Label key={option.value} htmlFor={id || name}>
           <StyledEnumeration

--- a/buffet/src/components/InputNumber/index.js
+++ b/buffet/src/components/InputNumber/index.js
@@ -17,6 +17,7 @@ import StyledInputNumber from '../../styled/InputNumber';
 function InputNumber({
   autoFocus,
   id,
+  className,
   name,
   onChange,
   tabIndex,
@@ -35,7 +36,7 @@ function InputNumber({
   };
 
   return (
-    <StyledInputNumber>
+    <StyledInputNumber className={className}>
       <RcInputNumber
         {...rest}
         autoFocus={autoFocus}

--- a/buffet/src/components/InputText/index.js
+++ b/buffet/src/components/InputText/index.js
@@ -25,12 +25,13 @@ function InputText({
   tabIndex,
   type,
   value,
+  className,
   ...rest
 }) {
   const [showPassword, togglePassword] = useState(false);
 
   return (
-    <InputWrapper>
+    <InputWrapper className={className}>
       {(type === 'search' || type === 'email') && <Icon type={type} />}
       {type === 'password' && (
         <button

--- a/buffet/src/components/Label/index.js
+++ b/buffet/src/components/Label/index.js
@@ -23,16 +23,22 @@ function Label(props) {
     return props.children;
   })();
 
-  return <StyledLabel htmlFor={props.htmlFor}>{content}</StyledLabel>;
+  return (
+    <StyledLabel htmlFor={props.htmlFor} className={props.className}>
+      {content}
+    </StyledLabel>
+  );
 }
 
 Label.defaultProps = {
   children: null,
+  className: null,
   message: null,
 };
 
 Label.propTypes = {
   children: PropTypes.node,
+  className: PropTypes.string,
   htmlFor: PropTypes.string.isRequired,
   message: PropTypes.oneOfType([
     PropTypes.func,

--- a/buffet/src/components/List/index.js
+++ b/buffet/src/components/List/index.js
@@ -12,9 +12,9 @@ import {
 import ListRow from '../ListRow';
 import StyledList from '../../styled/List';
 
-function List({ items, customRowComponent }) {
+function List({ className, items, customRowComponent }) {
   return (
-    <StyledList>
+    <StyledList className={className}>
       <table>
         <tbody>
           {items.map(item =>

--- a/buffet/src/components/Table/index.js
+++ b/buffet/src/components/Table/index.js
@@ -15,6 +15,7 @@ import ActionCollapse from './ActionCollapse';
 
 function Table({
   bulkActionProps,
+  className,
   customRow,
   headers,
   onChangeSort,
@@ -39,7 +40,7 @@ function Table({
   const shouldDisplayEmptyRow = rows.length === 0;
 
   return (
-    <StyledTable>
+    <StyledTable className={className}>
       <table className="">
         <TableHeader
           headers={headers}
@@ -108,6 +109,7 @@ Table.defaultProps = {
     translatedNumberOfEntries: 'entries',
     translatedAction: 'Delete all',
   },
+  className: null,
   customRow: null,
   headers: [],
   onChangeSort: () => {},
@@ -130,6 +132,7 @@ Table.propTypes = {
     translatedNumberOfEntries: PropTypes.string,
     translatedNumberOfEntry: PropTypes.string,
   }),
+  className: PropTypes.string,
   customRow: PropTypes.func,
   headers: PropTypes.arrayOf(
     PropTypes.shape({

--- a/buffet/src/components/TimePicker/index.js
+++ b/buffet/src/components/TimePicker/index.js
@@ -201,7 +201,7 @@ function TimePicker(props) {
   };
 
   return (
-    <TimePickerWrapper ref={wrapperRef}>
+    <TimePickerWrapper ref={wrapperRef} className={props.className}>
       <StyledTimePicker
         {...props}
         autoComplete="off"
@@ -232,12 +232,14 @@ function TimePicker(props) {
 }
 
 TimePicker.defaultProps = {
+  className: null,
   onChange: () => {},
   seconds: false,
   value: '',
 };
 
 TimePicker.propTypes = {
+  className: PropTypes.string,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   seconds: PropTypes.bool,

--- a/buffet/src/components/Toggle/index.js
+++ b/buffet/src/components/Toggle/index.js
@@ -15,9 +15,9 @@ import Label from '../Label';
 
 import StyledToggle, { ToggleWrapper } from '../../styled/Toggle';
 
-function Toggle({ id, name, onChange, value }) {
+function Toggle({ id, className, name, onChange, value }) {
   return (
-    <ToggleWrapper>
+    <ToggleWrapper className={className}>
       <Label htmlFor={id || name}>
         <StyledToggle
           checked={value}


### PR DESCRIPTION
This is important for users with styling libraries like styled-components and glamorous to override styles provided by a third party component library. 

Fixes #32