### PR TITLE
Fix input number focus out bug

### DIFF
--- a/packages/buffetjs-core/src/components/InputNumber/index.js
+++ b/packages/buffetjs-core/src/components/InputNumber/index.js
@@ -20,14 +20,16 @@ function InputNumber({
   ...rest
 }) {
   const handleChange = data => {
-    const target = {
-      id,
-      name,
-      type: 'number',
-      value: data,
-    };
+    if (data !== null) {
+      const target = {
+        id,
+        name,
+        type: 'number',
+        value: data,
+      };
 
-    onChange({ target });
+      onChange({ target });
+    }
   };
 
   return (


### PR DESCRIPTION
The input number sent a value when focusing out the input which caused issue if the input was not touched. This PR fixes this bug