### PR TITLE
Errors as an object for custom inputs

### DIFF
--- a/packages/buffetjs-custom/src/components/Inputs/index.js
+++ b/packages/buffetjs-custom/src/components/Inputs/index.js
@@ -156,7 +156,7 @@ Inputs.defaultProps = {
 Inputs.propTypes = {
   customInputs: PropTypes.object,
   description: PropTypes.string,
-  error: PropTypes.string,
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   id: PropTypes.string,
   label: PropTypes.string,
   name: PropTypes.string.isRequired,

--- a/packages/buffetjs-icons/src/components/Pending/index.js
+++ b/packages/buffetjs-icons/src/components/Pending/index.js
@@ -26,7 +26,7 @@ const Pending = ({ fill, ...rest }) => (
 );
 
 Pending.defaultProps = {
-  fill: '#6DBB1A',
+  fill: '#ffb500',
 };
 
 Pending.propTypes = {


### PR DESCRIPTION
Error can be a string or an object to enable multiple errors