### PR TITLE
fix(Inputs): input with type number not show 0 value

### DIFF
--- a/docs/stories/customComponents/Inputs.stories.js
+++ b/docs/stories/customComponents/Inputs.stories.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from '@storybook/react';
 import { Inputs } from '@buffetjs/custom';
+import { isUndefined } from 'lodash';
 
 import Presentation from '../ui/Presentation';
 import Pre from '../ui/Pre';
@@ -145,7 +146,11 @@ function InputStory() {
                     name={input}
                     {...form[input]}
                     onChange={handleChange}
-                    value={state[input] || form[input].value}
+                    value={
+                      isUndefined(state[input])
+                        ? form[input].value
+                        : state[input]
+                    }
                   />
                 </div>
               ))}

--- a/packages/buffetjs-custom/src/components/Inputs/index.js
+++ b/packages/buffetjs-custom/src/components/Inputs/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { get, isEmpty, isFunction } from 'lodash';
+import { get, isEmpty, isFunction, isUndefined } from 'lodash';
 import {
   DatePicker,
   Checkbox,
@@ -63,6 +63,9 @@ function Inputs({
     case 'checkbox':
     case 'bool':
       inputValue = value || false;
+      break;
+    case 'number':
+      inputValue = isUndefined(value) ? '' : value;
       break;
     default:
       inputValue = value || '';


### PR DESCRIPTION
this fix apllies to https://github.com/strapi/strapi/issues/3832

I'd suggest to be very careful when using <Inputs /> component. There may be few solutions:

1. Use Inputs without saving state (like uncontrolled component), because with this you would always check type. Or only save input value, and not passing it down to Inputs component. Rather hard to do and maitain.

2. Split Inputs into separate Input for type, like many libs do. So you'll have TextInput, NumberInput, CheckboxInput, etc.

3. Change logic behind <Inputs /> component.

I'd gladly help with 2 or 3 if you let me, but probably it would need some discussion. 

EDIT:
I thought about this a bit more, and here's extra points:

3.5. Changing logic will have same flaws as now unless...

4. parent which controlls Inputs with state will pass only value down without extra logic like `value={value || ''}`. It's component responsibility to do with value what is needed.

5. May be fragile, bet let's say we assume that number input cannot use empty string as value. In this case we will set value to 0. Input still will allow to be undefined (empty value). So condition in component will look like this: `value={type === 'number' && value === '' ? 0 : value || ''}`.

6. I wonder why Inputs it's not controlled (have state). Because with state we can controls calling onChange Now there may be unnecessary onChange and rerenders. Example: Parent gets new value, value is passed down to Inputs, input calls onChange and new value is set as Parent's state and passed down to Inputs. And that's fine but cycle may repeats. Input again calls onChange, parent's onChange change state, but because value not changes, throu react's reconcilation process render will not be trigger. With contolled component we can limit unnecessary operations.

I think the best approach will be 1 and 4 + maybe some extra login in Inputs component.