### PR TITLE
Fix hooks event listener

### DIFF
--- a/packages/buffetjs-core/src/components/TimePicker/index.js
+++ b/packages/buffetjs-core/src/components/TimePicker/index.js
@@ -148,57 +148,77 @@ function TimePicker(props) {
   }, [isOpen, currentTimeSelected]);
 
   // Custom hook to close the TimeList
-  useEventListener('click', event => {
-    if (!wrapperRef.current.contains(event.target)) {
-      setIsOpen(false);
-    }
-  });
+  useEventListener(
+    'click',
+    event => {
+      if (!wrapperRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    },
+    isOpen
+  );
 
   // Custom hook to select a time using the keyboard's up arrow
-  useShortcutEffect('arrowUp', () => {
-    if (isOpen) {
-      const currentIndex = options.findIndex(
-        o => o.value === currentTimeSelected
-      );
-      if (!currentIndex) return;
-      const nextIndex = currentIndex - 1;
+  useShortcutEffect(
+    'arrowUp',
+    () => {
+      if (isOpen) {
+        const currentIndex = options.findIndex(
+          o => o.value === currentTimeSelected
+        );
+        if (!currentIndex) return;
+        const nextIndex = currentIndex - 1;
 
-      const nextTime = options[nextIndex] || options[currentIndex];
+        const nextTime = options[nextIndex] || options[currentIndex];
 
-      updateTime(nextTime.value);
-    }
-  });
+        updateTime(nextTime.value);
+      }
+    },
+    isOpen
+  );
 
   // Custom hook to select a time using the keyboard's down arrow
-  useShortcutEffect('arrowDown', () => {
-    if (isOpen) {
-      const currentIndex = options.findIndex(
-        o => o.value === currentTimeSelected
-      );
-      const lastIndex = options.length - 1;
-      if (currentIndex >= lastIndex) return;
-      const nextIndex = currentIndex + 1;
+  useShortcutEffect(
+    'arrowDown',
+    () => {
+      if (isOpen) {
+        const currentIndex = options.findIndex(
+          o => o.value === currentTimeSelected
+        );
+        const lastIndex = options.length - 1;
+        if (currentIndex >= lastIndex) return;
+        const nextIndex = currentIndex + 1;
 
-      const nextTime = options[nextIndex] || options[lastIndex];
+        const nextTime = options[nextIndex] || options[lastIndex];
 
-      updateTime(nextTime.value);
-    }
-  });
+        updateTime(nextTime.value);
+      }
+    },
+    isOpen
+  );
 
   // Custom hook to close the time list
-  useShortcutEffect('enter', () => {
-    if (isOpen) {
-      setIsOpen(false);
-      inputRef.current.blur();
-    }
-  });
+  useShortcutEffect(
+    'enter',
+    () => {
+      if (isOpen) {
+        setIsOpen(false);
+        inputRef.current.blur();
+      }
+    },
+    isOpen
+  );
 
-  useShortcutEffect('tab', () => {
-    if (isOpen) {
-      setIsOpen(false);
-      inputRef.current.blur();
-    }
-  });
+  useShortcutEffect(
+    'tab',
+    () => {
+      if (isOpen) {
+        setIsOpen(false);
+        inputRef.current.blur();
+      }
+    },
+    isOpen
+  );
 
   const handleChange = ({ target }) => {
     updateTime(target.value);
@@ -244,20 +264,21 @@ function TimePicker(props) {
         <Icon icon="time" />
       </IconWrapper>
       <TimeList className={isOpen && 'displayed'} ref={listRef}>
-        {options.map(option => (
-          <li key={option.value} ref={listRefs[option.value]}>
-            <input
-              type="radio"
-              onChange={handleClick}
-              value={option.value}
-              id={option.value}
-              name="time"
-              checked={option.value === currentTimeSelected}
-              tabIndex="0"
-            />
-            <label htmlFor={option.value}>{option.label}</label>
-          </li>
-        ))}
+        {isOpen &&
+          options.map(option => (
+            <li key={option.value} ref={listRefs[option.value]}>
+              <input
+                type="radio"
+                onChange={handleClick}
+                value={option.value}
+                id={option.value}
+                name="time"
+                checked={option.value === currentTimeSelected}
+                tabIndex="0"
+              />
+              <label htmlFor={option.value}>{option.label}</label>
+            </li>
+          ))}
       </TimeList>
     </TimePickerWrapper>
   );

--- a/packages/buffetjs-core/src/hooks/useActiveKeys/index.js
+++ b/packages/buffetjs-core/src/hooks/useActiveKeys/index.js
@@ -1,20 +1,28 @@
 import { useState } from 'react';
 import useEventListener from '../useEventListener';
 
-function useActiveKeys() {
+function useActiveKeys(isEnabled = true) {
   const [activeKeys, setActiveKeys] = useState([]);
 
   // Add keys to the array on down
-  useEventListener('keydown', e => {
-    if (!activeKeys.includes(e.keyCode)) {
-      setActiveKeys(prevKeys => [...prevKeys, e.keyCode]);
-    }
-  });
+  useEventListener(
+    'keydown',
+    e => {
+      if (!activeKeys.includes(e.keyCode)) {
+        setActiveKeys(prevKeys => [...prevKeys, e.keyCode]);
+      }
+    },
+    isEnabled
+  );
 
   // Remove keys on up
-  useEventListener('keyup', e => {
-    setActiveKeys(prevKeys => prevKeys.filter(key => key !== e.keyCode));
-  });
+  useEventListener(
+    'keyup',
+    e => {
+      setActiveKeys(prevKeys => prevKeys.filter(key => key !== e.keyCode));
+    },
+    isEnabled
+  );
 
   return activeKeys;
 }

--- a/packages/buffetjs-core/src/hooks/useEventListener/index.js
+++ b/packages/buffetjs-core/src/hooks/useEventListener/index.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-function useEventListener(event, eventListener) {
+function useEventListener(event, eventListener, isEnabled = true) {
   const listenerRef = useRef();
   listenerRef.current = eventListener;
 
@@ -9,12 +9,16 @@ function useEventListener(event, eventListener) {
       listenerRef.current(e);
     }
 
-    window.addEventListener(event, handleEvent);
+    if (isEnabled) {
+      window.addEventListener(event, handleEvent);
+    } else {
+      window.removeEventListener(event, handleEvent);
+    }
 
     return () => {
       window.removeEventListener(event, handleEvent);
     };
-  }, [event]);
+  }, [event, isEnabled]);
 }
 
 export default useEventListener;

--- a/packages/buffetjs-core/src/hooks/useShortcutEffect/index.js
+++ b/packages/buffetjs-core/src/hooks/useShortcutEffect/index.js
@@ -15,8 +15,8 @@ function getShortcutKeys(keys) {
   return keys.split('+').map(value => keyCodes[value.toLowerCase()]);
 }
 
-function useShortcutEffect(shortcut, listener) {
-  const activeKeys = useActiveKeys();
+function useShortcutEffect(shortcut, listener, isEnabled = true) {
+  const activeKeys = useActiveKeys(isEnabled);
   const listenerRef = useRef();
   listenerRef.current = listener;
 


### PR DESCRIPTION


This PR improve the performances of the `TimePicker` component by enabling the event listeners only when the list is opened.

Also, the current hooks can now have a third argument to add and remove event listeners programmatically. 

However I am starting to think that these hooks should belong in their own package.