### PR TITLE
fix(TimePicker): selected option better contrast

### DIFF
--- a/packages/buffetjs-styles/src/components/TimeList/index.js
+++ b/packages/buffetjs-styles/src/components/TimeList/index.js
@@ -14,7 +14,7 @@ const TimeList = styled.ul`
   font-family: 'Lato';
   font-weight: 600;
   font-size: ${sizes.input.fontSize};
-  color: ${colors.greyIconColor};
+  color: ${colors.greyPlaceholder};
   border: 1px solid transparent;
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
@@ -51,7 +51,7 @@ const TimeList = styled.ul`
       cursor: pointer;
       &:checked + label,
       &:hover + label {
-        background-color: ${colors.greyIconBkgd};
+        background-color: ${colors.lightGrey};
       }
     }
     label {


### PR DESCRIPTION
@soupette selected option was almost not visible.

Do you have some style guide? I noticed that colors are not prearranged. I think you should have some design system (theme) at least for typography and colors (basic colors + tints/shades), which should be exported for later use in strapi.

And then go with rule, that only existing colors may be used.

I've done this several times so I'll be happy to help.