### PR TITLE
Fix useIsMounted hook usage

### DIFF
--- a/packages/buffetjs-hooks/src/useIsMounted/index.js
+++ b/packages/buffetjs-hooks/src/useIsMounted/index.js
@@ -13,7 +13,7 @@ function useIsMounted() {
     };
   }, []);
 
-  return () => ref.current;
+  return ref.current;
 }
 
 export default useIsMounted;


### PR DESCRIPTION
Now we can use the useIsMounted hook doing `cont isMounted = useIsMounted()`  instead of `const isMounted = useIsMounted()()`