### PR TITLE
Add missing peer dependency

### DIFF
--- a/packages/buffetjs-core/package.json
+++ b/packages/buffetjs-core/package.json
@@ -27,7 +27,8 @@
     "moment": "^2.24.0",
     "rc-input-number": "^4.5.0",
     "react-dates": "^21.5.1",
-    "react-moment-proptypes": "^1.7.0"
+    "react-moment-proptypes": "^1.7.0",
+    "react-with-direction": "^1.3.1"
   },
   "devDependencies": {
     "enzyme": "^3.10.0",


### PR DESCRIPTION
When using Strapi, I noticed `react-dates@21.8.0` was missing `react-with-direction@^1.3.1`.