### PR TITLE
Fix table header cell tags

### DIFF
--- a/packages/buffetjs-core/src/components/Table/index.js
+++ b/packages/buffetjs-core/src/components/Table/index.js
@@ -52,7 +52,7 @@ function Table({
           onChangeSort={onChangeSort}
           onSelectAll={onSelectAll}
           rows={rows}
-          shouldAddTd={rowLinks.length > 0}
+          addCell={rowLinks.length > 0}
           sortBy={sortBy}
           sortOrder={sortOrder}
           withBulkAction={withBulkAction}

--- a/packages/buffetjs-core/src/components/Table/index.js
+++ b/packages/buffetjs-core/src/components/Table/index.js
@@ -52,7 +52,7 @@ function Table({
           onChangeSort={onChangeSort}
           onSelectAll={onSelectAll}
           rows={rows}
-          addCell={rowLinks.length > 0}
+          shouldAddCell={rowLinks.length > 0}
           sortBy={sortBy}
           sortOrder={sortOrder}
           withBulkAction={withBulkAction}

--- a/packages/buffetjs-core/src/components/TableHeader/index.js
+++ b/packages/buffetjs-core/src/components/TableHeader/index.js
@@ -12,11 +12,11 @@ import Icon from '../Icon';
 
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 function TableHeader({
-  shouldAddCell,
   headers,
   onChangeSort,
   onSelectAll,
   rows,
+  shouldAddCell,
   sortBy,
   sortOrder,
   withBulkAction,

--- a/packages/buffetjs-core/src/components/TableHeader/index.js
+++ b/packages/buffetjs-core/src/components/TableHeader/index.js
@@ -12,7 +12,7 @@ import Icon from '../Icon';
 
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 function TableHeader({
-  addCell,
+  shouldAddCell,
   headers,
   onChangeSort,
   onSelectAll,
@@ -65,25 +65,24 @@ function TableHeader({
             </th>
           );
         })}
-        {addCell && <th />}
+        {shouldAddCell && <th />}
       </tr>
     </thead>
   );
 }
 
 TableHeader.defaultProps = {
-  addCell: false,
   headers: [],
   onChangeSort: () => {},
   onSelectAll: () => {},
   rows: [],
+  shouldAddCell: false,
   sortBy: null,
   sortOrder: 'asc',
   withBulkAction: false,
 };
 
 TableHeader.propTypes = {
-  addCell: PropTypes.bool,
   headers: PropTypes.arrayOf(
     PropTypes.shape({
       isSortEnabled: PropTypes.bool,
@@ -94,6 +93,7 @@ TableHeader.propTypes = {
   onChangeSort: PropTypes.func,
   onSelectAll: PropTypes.func,
   rows: PropTypes.instanceOf(Array),
+  shouldAddCell: PropTypes.bool,
   sortBy: PropTypes.string,
   sortOrder: PropTypes.string,
   withBulkAction: PropTypes.bool,

--- a/packages/buffetjs-core/src/components/TableHeader/index.js
+++ b/packages/buffetjs-core/src/components/TableHeader/index.js
@@ -12,11 +12,11 @@ import Icon from '../Icon';
 
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 function TableHeader({
+  addCell,
   headers,
   onChangeSort,
   onSelectAll,
   rows,
-  shouldAddTd,
   sortBy,
   sortOrder,
   withBulkAction,
@@ -29,13 +29,13 @@ function TableHeader({
     <thead>
       <tr>
         {withBulkAction && (
-          <td className="checkCell">
+          <th className="checkCell">
             <Checkbox
               onChange={onSelectAll}
               checked={checked}
               someChecked={shouldDisplayNotChecked}
             />
-          </td>
+          </th>
         )}
         {headers.map(header => {
           const { isSortEnabled, name, value } = header;
@@ -48,7 +48,7 @@ function TableHeader({
 
           return (
             // eslint-disable-next-line jsx-a11y/click-events-have-key-events
-            <td
+            <th
               key={value}
               onClick={() => {
                 onChangeSort({
@@ -62,27 +62,28 @@ function TableHeader({
                 {name}
                 {shouldDisplaySort && <Icon icon={sortOrder || 'asc'} />}
               </p>
-            </td>
+            </th>
           );
         })}
-        {shouldAddTd && <td />}
+        {addCell && <th />}
       </tr>
     </thead>
   );
 }
 
 TableHeader.defaultProps = {
+  addCell: false,
   headers: [],
   onChangeSort: () => {},
   onSelectAll: () => {},
   rows: [],
-  shouldAddTd: false,
   sortBy: null,
   sortOrder: 'asc',
   withBulkAction: false,
 };
 
 TableHeader.propTypes = {
+  addCell: PropTypes.bool,
   headers: PropTypes.arrayOf(
     PropTypes.shape({
       isSortEnabled: PropTypes.bool,
@@ -93,7 +94,6 @@ TableHeader.propTypes = {
   onChangeSort: PropTypes.func,
   onSelectAll: PropTypes.func,
   rows: PropTypes.instanceOf(Array),
-  shouldAddTd: PropTypes.bool,
   sortBy: PropTypes.string,
   sortOrder: PropTypes.string,
   withBulkAction: PropTypes.bool,

--- a/packages/buffetjs-styles/src/components/Table/index.js
+++ b/packages/buffetjs-styles/src/components/Table/index.js
@@ -79,8 +79,7 @@ const Table = styled.div`
       line-height: 0.1rem;
       font-weight: ${sizes.fontWeight.bold};
       text-transform: capitalize;
-      th,
-      td {
+      th {
         background-color: ${colors.greyHeader};
         height: ${sizes.table.header.height};
         p {

--- a/packages/buffetjs-styles/src/components/Table/index.js
+++ b/packages/buffetjs-styles/src/components/Table/index.js
@@ -65,6 +65,7 @@ const Table = styled.div`
     padding-left: 2.5em;
     padding-right: 2.5em;
     text-align: left;
+    th,
     td {
       font-size: 1.3rem;
       padding: 0 25px;
@@ -78,6 +79,7 @@ const Table = styled.div`
       line-height: 0.1rem;
       font-weight: ${sizes.fontWeight.bold};
       text-transform: capitalize;
+      th,
       td {
         background-color: ${colors.greyHeader};
         height: ${sizes.table.header.height};


### PR DESCRIPTION
**Description of what you did:**

Changed the cells in the table header from `td` -> `th` as should be used in `thead`.

This allows correct usage of the styled component `Table` with a custom generated table.