### PR TITLE
Update index.js

### DIFF
--- a/packages/buffetjs-custom/src/components/Inputs/index.js
+++ b/packages/buffetjs-custom/src/components/Inputs/index.js
@@ -142,7 +142,7 @@ function Inputs({
             value={inputValue}
           />
           {!error && description && (
-            <Description id={descriptionId}>{description}</Description>
+            <Description id={descriptionId} title={description}>{description}</Description>
           )}
           {error && <ErrorMessage id={errorId}>{error}</ErrorMessage>}
         </Wrapper>


### PR DESCRIPTION
The `Description` shows ellipsis when it's too long. Without a `title` tag, there is no way for the user to read the full description