### PR TITLE
Fix button text alignment

### DIFF
--- a/packages/buffetjs-styles/src/assets/styles/sizes.js
+++ b/packages/buffetjs-styles/src/assets/styles/sizes.js
@@ -10,7 +10,6 @@ const sizes = {
       large: '30px',
     },
     padding: {
-      bottom: '2px',
       leftRight: '15px',
     },
     minWidth: '140px',

--- a/packages/buffetjs-styles/src/components/Button/index.js
+++ b/packages/buffetjs-styles/src/components/Button/index.js
@@ -13,10 +13,10 @@ import mixins from '../../assets/styles/mixins';
 const Button = styled.button`
   /* General style */
   height: ${sizes.button.height.large};
-  padding: 0 ${sizes.button.padding.leftRight} ${sizes.button.padding.bottom};
+  padding: 0 ${sizes.button.padding.leftRight};
   font-weight: ${sizes.fontWeight.bold};
   font-size: 1.3rem;
-  line-height: normal;
+  line-height: ${sizes.button.height.large};
   border-radius: ${sizes.borderRadius};
   cursor: pointer;
   outline: 0;


### PR DESCRIPTION
Fixes button misaligned text described in https://github.com/strapi/strapi/issues/5998

To properly align the text in the center, I removed the padding-bottom and fixed the line-height to be the same as the height.

**Before:**
![strapi-button-issue-before](https://user-images.githubusercontent.com/1661925/100050894-5441a300-2dcf-11eb-922a-f891efc3cc76.png)

**After:**
![strapi-button-issue-after](https://user-images.githubusercontent.com/1661925/100050901-56a3fd00-2dcf-11eb-9b72-08c25f5dcc9e.png)

**Side by side:**
![strapi-button-issue](https://user-images.githubusercontent.com/1661925/100051164-11cc9600-2dd0-11eb-9e44-1dc1413fbb45.png)
