### PR TITLE
Consolidate lodash dependency to 4.17.20

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "bootstrap": "^4.3.1",
-    "lodash": "4.17.19",
+    "lodash": "4.17.20",
     "moment": "^2.24.0",
     "prop-types": "^15.7.2",
     "react-highlight": "^0.12.0",

--- a/packages/buffetjs-core/package.json
+++ b/packages/buffetjs-core/package.json
@@ -40,7 +40,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "invariant": "^2.2.4",
-    "lodash": "4.17.19",
+    "lodash": "4.17.20",
     "moment": "^2.24.0",
     "prop-types": "^15.7.2",
     "rc-input-number": "^4.5.0",
@@ -101,7 +101,7 @@
     "webpack-cli": "^3.3.12"
   },
   "peerDependencies": {
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.20",
     "react": "^16.9.0",
     "react-dom": "^16.8.6",
     "styled-components": "^5.0.0"

--- a/packages/buffetjs-custom/package.json
+++ b/packages/buffetjs-custom/package.json
@@ -34,7 +34,7 @@
     "@buffetjs/core": "3.3.3",
     "@buffetjs/styles": "3.3.3",
     "@buffetjs/utils": "3.3.3",
-    "lodash": "4.17.19",
+    "lodash": "4.17.20",
     "moment": "^2.24.0",
     "prop-types": "^15.5.10",
     "react-moment-proptypes": "^1.7.0"
@@ -89,7 +89,7 @@
     "webpack-cli": "~3.3.12"
   },
   "peerDependencies": {
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.20",
     "react": "^16.8.6",
     "styled-components": "^5.0.0"
   },

--- a/packages/buffetjs-utils/package.json
+++ b/packages/buffetjs-utils/package.json
@@ -28,7 +28,7 @@
   "author": "Strapi team",
   "license": "MIT",
   "dependencies": {
-    "lodash": "4.17.19",
+    "lodash": "4.17.20",
     "yup": "^0.27.0"
   },
   "devDependencies": {
@@ -64,7 +64,7 @@
     "webpack-cli": "~3.3.12"
   },
   "peerDependencies": {
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.20",
     "yup": "^0.27.0"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14802,10 +14802,10 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.19, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+lodash@4.17.20, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR makes the lodash dependency version equal to the one used in strapi (https://github.com/strapi/strapi/pull/8861) so users only need to install one copy.

I am curious why lodash is both a dependency and a peerDependency. I've updated both to be sure.