### PR TITLE
Add radius to card

### DIFF
--- a/packages/buffetjs-custom/src/components/List/index.js
+++ b/packages/buffetjs-custom/src/components/List/index.js
@@ -17,9 +17,10 @@ function List({
   isLoading,
   items,
   customRowComponent,
+  ...props
 }) {
   return (
-    <Card>
+    <Card {...props}>
       <Padded right left size="md">
         <ListHeader title={title} subtitle={subtitle} button={button} />
       </Padded>

--- a/packages/buffetjs-styles/src/components/Card/index.js
+++ b/packages/buffetjs-styles/src/components/Card/index.js
@@ -24,6 +24,7 @@ const Card = styled.div`
       overflow-x: inherit;
     }
   }
+  border-radius: ${p => p.radius};
 `;
 
 export default Card;


### PR DESCRIPTION
Adds a "radius" props to the card component so that we can define it outside buffetjs.

Pretty convenient when trying to add a radius on the custom List component