### PR TITLE
Update lodash to remove prototype pollution vuln

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "bootstrap": "^4.3.1",
-    "lodash": "4.17.20",
+    "lodash": "4.17.21",
     "moment": "^2.24.0",
     "prop-types": "^15.7.2",
     "react-highlight": "^0.12.0",

--- a/packages/buffetjs-core/package.json
+++ b/packages/buffetjs-core/package.json
@@ -40,7 +40,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "invariant": "^2.2.4",
-    "lodash": "4.17.20",
+    "lodash": "4.17.21",
     "moment": "^2.24.0",
     "prop-types": "^15.7.2",
     "rc-input-number": "^4.5.0",
@@ -101,7 +101,7 @@
     "webpack-cli": "^3.3.12"
   },
   "peerDependencies": {
-    "lodash": "^4.17.20",
+    "lodash": "4.17.21",
     "react": "^16.9.0",
     "react-dom": "^16.8.6",
     "styled-components": "^5.0.0"

--- a/packages/buffetjs-custom/package.json
+++ b/packages/buffetjs-custom/package.json
@@ -34,7 +34,7 @@
     "@buffetjs/core": "3.3.5",
     "@buffetjs/styles": "3.3.5",
     "@buffetjs/utils": "3.3.5",
-    "lodash": "4.17.20",
+    "lodash": "4.17.21",
     "moment": "^2.24.0",
     "prop-types": "^15.5.10",
     "react-moment-proptypes": "^1.7.0"
@@ -89,7 +89,7 @@
     "webpack-cli": "~3.3.12"
   },
   "peerDependencies": {
-    "lodash": "^4.17.20",
+    "lodash": "4.17.21",
     "react": "^16.8.6",
     "styled-components": "^5.0.0"
   },

--- a/packages/buffetjs-utils/package.json
+++ b/packages/buffetjs-utils/package.json
@@ -28,7 +28,7 @@
   "author": "Strapi team",
   "license": "MIT",
   "dependencies": {
-    "lodash": "4.17.20",
+    "lodash": "4.17.21",
     "yup": "^0.27.0"
   },
   "devDependencies": {
@@ -64,7 +64,7 @@
     "webpack-cli": "~3.3.12"
   },
   "peerDependencies": {
-    "lodash": "^4.17.20",
+    "lodash": "4.17.21",
     "yup": "^0.27.0"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14802,7 +14802,12 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.20, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10:
+lodash@4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
Some of the outdated lodash versions were making it into users projects, matching lodash version with what is in the monorepo